### PR TITLE
Improvements

### DIFF
--- a/files/wireguard@.service
+++ b/files/wireguard@.service
@@ -11,8 +11,11 @@ Documentation=https://git.zx2c4.com/WireGuard/about/src/tools/wg.8
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+EnvironmentFile=/etc/wireguard/.%i
 ExecStartPre=/sbin/ip link add dev %i type wireguard
+ExecStartPre=/sbin/ip addr add dev %i ${VIRTUAL_IP}
 ExecStart=/usr/bin/wg setconf %i /etc/wireguard/%i.conf
+ExecStartPost=/sbin/ip link set up dev %i
 ExecStop=/sbin/ip link del %i
 ExecReload=/usr/bin/wg setconf %i /etc/wireguard/%i.conf
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,21 +1,35 @@
 class wireguard (
-  Array[Hash] $tunnels = [],
-  Array[Hash] $simple_tunnels = [],
+  Hash[String, Struct[
+    {
+      ensure      => Optional[String],
+      private_key => String,
+      listen_port => Integer,
+      virtual_ip  => String,
+      peers       => Hash,
+    }
+  ]] $tunnels = {},
+  Hash[String, Struct[
+    {
+      ensure           => Optional[String],
+      private_key      => String,
+      listen_port      => Integer,
+      virtual_ip       => String,
+      peer_public_key  => String,
+      peer_allowed_ips => Optional[String],
+      peer_endpoint    => Optional[String],
+    }
+  ]] $simple_tunnels = [],
 ) {
   include wireguard::packages
 
-  $tunnels.each |$tunnel| {
-    $tunnel.each |$name, $params| {
-      wireguard::tunnel { $name:
-        * => $params,
-      }
+  $tunnels.each |$name, $params| {
+    wireguard::tunnel { $name:
+      * => $params,
     }
   }
-  $simple_tunnels.each |$simple_tunnel| {
-    $simple_tunnel.each |$name, $params| {
-      wireguard::simple_tunnel { $name:
-        * => $params,
-      }
+  $simple_tunnels.each |$name, $params| {
+    wireguard::simple_tunnel { $name:
+      * => $params,
     }
   }
 }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -2,14 +2,37 @@ class wireguard::packages {
   if($::osfamily == 'debian') {
     include apt
 
-    apt::pin {'wireguard':
-      packages => ['wireguard-dkms', 'wireguard-tools'],
-      release  => 'experimental',
-      priority => 501,
-      require  => Apt::Source['debian_unstable'],
+    $osname = downcase($facts['os']['name'])
+
+    case $osname {
+      'ubuntu' : {
+        apt::source { "wireguard-$::lsbdistcodename" :
+          location => "http://ppa.launchpad.net/wireguard/wireguard/$osname",
+          release  => $::lsbdistcodename,
+          repos    => 'main',
+          key      => {
+            'id'     => 'E1B39B6EF6DDB96564797591AE33835F504A1A25',
+            'server' => 'pgp.mit.edu',
+          },
+          include  => {
+            'src' => false,
+          },
+        }
+        [Apt::Source["wireguard-$::lsbdistcodename"], Class['apt::update']] -> Package<| title == 'wireguard-tools' |>
+        [Apt::Source["wireguard-$::lsbdistcodename"], Class['apt::update']] -> Package<| title == 'wireguard-dkms' |>
+      }
+      default : {
+        apt::pin {'wireguard':
+          packages => ['wireguard-dkms', 'wireguard-tools'],
+          release  => 'experimental',
+          priority => 501,
+          require  => Apt::Source['debian_unstable'],
+        }
+
+        [Apt::Pin['wireguard'], Class['apt::update']] -> Package<| title == 'wireguard-dkms' |>
+        [Apt::Pin['wireguard'], Class['apt::update']] -> Package<| title == 'wireguard-tools' |>
+      }
     }
-    [Apt::Pin['wireguard'], Class['apt::update']] -> Package<| title == 'wireguard-dkms' |>
-    [Apt::Pin['wireguard'], Class['apt::update']] -> Package<| title == 'wireguard-tools' |>
   }
 
   package { ['wireguard-dkms', 'wireguard-tools']:

--- a/manifests/simple_tunnel.pp
+++ b/manifests/simple_tunnel.pp
@@ -2,28 +2,39 @@
 # peer. It uses wireguard::tunnel internally.
 #
 # @param private_key the private key used here
+#
 # @param listen_port on which port wireguard should listen for incoming
 # connections. Chosen randomly if not specified
+#
 # @param peer_public_key The public key of the one and only peer @param
-# peer_allowed_ips A comma-separated list of ip (v4 or v6) addresses with CIDR
+#
+# @param virtual_ip virtual network also needs an IP address for each node so
+# that machines can communicate between each other over IP
+#
+# @param peer_allowed_ips A comma-separated list of ip (v4 or v6) addresses with CIDR
 # masks from which this peer is allowed to send incoming traffic and to which
 # outgoing traffic for this peer is directed. Defaults to 0.0.0.0/0 and ::/0.
+#
 # @param peer_endpoint An  endpoint  IP or hostname, followed by a colon, and
 # then a port number. This endpoint will be updated automatically to the most
 # recent source IP address and port of correctly authenticated packets from the
 # peer. Optional.
 
 define wireguard::simple_tunnel (
+  String  $ensure                    = 'present',
   String  $private_key,
   Integer $listen_port,
-  String $peer_public_key,
+  String  $peer_public_key,
+  String  $virtual_ip,
   Optional[String] $peer_allowed_ips = undef,
-  Optional[String] $peer_endpoint = undef,
+  Optional[String] $peer_endpoint    = undef,
 ) {
 
   wireguard::tunnel { $title:
+    ensure      => $ensure,
     private_key => $private_key,
     listen_port => $listen_port,
+    virtual_ip  => $virtual_ip,
     peers       => [{
       public_key  => $peer_public_key,
       allowed_ips => $peer_allowed_ips,

--- a/manifests/tunnel.pp
+++ b/manifests/tunnel.pp
@@ -11,45 +11,58 @@
 # detailed description.
 
 define wireguard::tunnel (
+  Enum['present','absent'] $ensure = 'present',
   String  $private_key,
   Integer $listen_port,
-  Array[Hash] $peers,
+  String  $virtual_ip,
+  Hash[String, Struct[
+    {
+      public_key           => String,
+      endpoint             => Optional[String], # FIXME
+      allowed_ips          => Optional[String],
+      preshared_key        => Optional[String],
+      persistent_keepalive => Optional[Integer[0-65535]],
+    }
+  ]] $peers = {},
 ) {
 
+  # Setup Packages
   include wireguard::packages
-  $peers.each |$peer| {
-    if($peer['public_key'] == undef) {
+
+  $peers.each |$key, $value| {
+    if($value['public_key'] == undef) {
       fail('public key is mandatory for each peer')
     }
-    $allowed_ips = $peer['allowed_ips']
+    $allowed_ips = $value['allowed_ips']
   }
 
+  file { "/etc/wireguard/.${title}" :
+    ensure  => $ensure,
+    content => "VIRTUAL_IP = $virtual_ip",
+    notify  => Service["wireguard@${title}.service"],
+  }
 
   file { "/etc/wireguard/${title}.conf":
-    ensure  => file,
+    ensure  => $ensure,
     content => epp('wireguard/config.epp', {
       private_key => $private_key,
       listen_port => $listen_port,
-      peers       => $peers.map |$peer| {
+      peers       => $peers.map |$key, $value| {
         {
-          'public_key'  => $peer['public_key'],
-          'endpoint'  => $peer['endpoint'],
-          'allowed_ips' => ($peer['allowed_ips'] != undef) ? { true => $peer['allowed_ips'], default => '0.0.0.0/0, ::/0'},
+          'public_key'           => $value['public_key'],
+          'endpoint'             => $value['endpoint'],
+          'allowed_ips'          => ($value['allowed_ips'] != undef) ? { true => $value['allowed_ips'], default => '0.0.0.0/0, ::/0'},
+          'preshared_key'        => $value['preshared_key'],
+          'persistent_keepalive' => $value['persistent_keepalive'],
         }
       },
     }),
-    notify  => Exec["wireguard@${title}_reload"],
-  }
-
-  exec {"wireguard@${title}_reload":
-    command     => "/bin/systemctl reload wireguard@${title}.service",
-    refreshonly => true,
-    require     => Service["wireguard@${title}.service"],
+    notify  => Service["wireguard@${title}.service"],
   }
 
   service { "wireguard@${title}.service":
-    ensure  => running,
-    enable  => true,
+    ensure  => if $ensure { 'running' } else { 'stopped' },
+    enable  => if $ensure { true } else { false },
     require => File["/etc/wireguard/${title}.conf"],
   }
 }

--- a/templates/config.epp
+++ b/templates/config.epp
@@ -1,8 +1,3 @@
-<%- | String $private_key,
-      Integer $listen_port,
-      Array[Hash] $peers = []
-| -%>
-
 [Interface]
 PrivateKey = <%= $private_key %>
 ListenPort = <%= $listen_port %>
@@ -10,8 +5,14 @@ ListenPort = <%= $listen_port %>
 <% $peers.each |$peer| { -%>
 [Peer]
 PublicKey  = <%= $peer['public_key'] %>
+<% if $peer['preshared_key'] { -%>
+PresharedKey = <%= $peer['preshared_key'] %>
+<% } -%>
 AllowedIPs = <%= $peer['allowed_ips'] %>
 <% if $peer['endpoint'] { -%>
 Endpoint   = <%= $peer['endpoint'] %>
+<% } -%>
+<% if $peer['persistent_keepalive'] { -%>
+PersistentKeepalive = <%= $peer['persistent_keepalive'] %>
 <% } -%>
 <% } %>


### PR DESCRIPTION
1. Array of hashes seems to be a bad idea. So converted into hash with Struct so we are limited to the type
2. Ubuntu package was not support, so added support for it
3. Service file had some bug with ip link up command was missing altogether
4. Service was getting reload if the file change, but seems like it does not work with template, since was not getting changed.

Sample Config

```
wireguard::tunnels:
  wg0:
    private_key: 'xyz'
    listen_port: 51820
    virtual_ip: 192.168.2.1/24
    peers:
      node01:
        public_key: 'efg'
        allowed_ips: 192.168.2.2/32
        endpoint: abc.com:51820
        persistent_keepalive: 10
      node02:
        public_key: 'abc'
        allowed_ips: 192.168.2.3/32
        endpoint: abc.com51822
        persistent_keepalive: 10
```